### PR TITLE
Show survey's 'complete button' only when editing a survey.

### DIFF
--- a/src/react/reactSurveyNavigation.tsx
+++ b/src/react/reactSurveyNavigation.tsx
@@ -22,7 +22,7 @@ export class SurveyNavigation extends SurveyNavigationBase {
         if (!this.survey || !this.survey.isNavigationButtonsShowing) return null;
         var prevButton = !this.survey.isFirstPage ? this.renderButton(this.handlePrevClick, this.survey.pagePrevText, this.css.navigation.prev) : null;
         var nextButton = !this.survey.isLastPage ? this.renderButton(this.handleNextClick, this.survey.pageNextText, this.css.navigation.next) : null;
-        var completeButton = this.survey.isLastPage ? this.renderButton(this.handleCompleteClick, this.survey.completeText, this.css.navigation.complete) : null;
+        var completeButton = this.survey.isLastPage && this.survey.isEditMode ? this.renderButton(this.handleCompleteClick, this.survey.completeText, this.css.navigation.complete) : null;
         return (
             <div className={this.css.footer}>
                 {prevButton}


### PR DESCRIPTION
I don't believe it makes sense in any scenario to show the
'complete button' when you're just viewing a survey in
display mode.