### PR TITLE
fixed headers display in markdown

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 
 ![alt tag](https://cloud.githubusercontent.com/assets/22315929/22462339/ed33f60a-e7bd-11e6-942b-72882e6bf1db.gif)
 
-##Getting started
+## Getting started
 [![Join the chat at https://gitter.im/andrewtelnov/surveyjs](https://badges.gitter.im/andrewtelnov/surveyjs.svg)](https://gitter.im/andrewtelnov/surveyjs?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge) 
 
 To find out more about the library go
@@ -41,12 +41,12 @@ Vue version:
 npm install survey-vue
 ```
 
-Or use Azure CDN: https://surveyjs.azureedge.net/{version name}/{filename}. You find all versions/builds in the [surveyjs/build repo](https://github.com/surveyjs/builds).
+Or use Azure CDN: https://surveyjs.azureedge.net/{version-name}/{filename}. You find all versions/builds in the [surveyjs/build repo](https://github.com/surveyjs/builds).
 
 Or dowload a version as zip file from [Releases](https://github.com/surveyjs/surveyjs/releases)
 
 
-##Building survey.js from sources
+## Building survey.js from sources
 
 To build library yourself:
 
@@ -74,17 +74,17 @@ To build library yourself:
 	```
 	This command will run unit tests usign [Karma](https://karma-runner.github.io/0.13/index.html)
 
-##Create your own question type.
+## Create your own question type.
 Explore the [example](https://github.com/surveyjs/surveyjs/tree/master/src/plugins) of adding a new question type into your survey library.
 
-##Use 3rd party controls as question widgets.
+## Use 3rd party controls as question widgets.
 Explore the [example](http://surveyjs.org/examples/react/custom-widget-datepicker.html) based on jquery datepicker
 
-##License
+## License
 
 MIT license - [http://www.opensource.org/licenses/mit-license.php](http://www.opensource.org/licenses/mit-license.php)
 
 
-##Visual Editor
+## Visual Editor
 Visual Editor [site](http://editor.surveyjs.io)
 Visual Editor sources are [here](https://github.com/surveyjs/editor)


### PR DESCRIPTION
just added space, so GitHub markdown will show headers correctly, and added "-" in the url placeholder, so markdown will recognize entire url.