### PR TITLE
Enum values are now forced into lowercase

### DIFF
--- a/src/page.ts
+++ b/src/page.ts
@@ -7,7 +7,7 @@ import {PanelModel, PanelModelBase, QuestionRowModel} from "./panel";
 
 export class PageModel extends PanelModelBase implements IPage {
     private numValue: number = -1;
-    public navigationButtonsVisibility: string = "inherit";
+    private navigationButtonsVisibilityValue: string = "inherit";
     constructor(public name: string = "") {
         super(name);
     }
@@ -17,6 +17,10 @@ export class PageModel extends PanelModelBase implements IPage {
         if (this.numValue == value) return;
         this.numValue = value;
         this.onNumChanged(value);
+    }
+    public get navigationButtonsVisibility(): string { return this.navigationButtonsVisibilityValue; }
+    public set navigationButtonsVisibility(newValue: string) {
+      this.navigationButtonsVisibilityValue = newValue.toLowerCase();
     }
     protected getRendredTitle(str: string): string {
         str = super.getRendredTitle(str);

--- a/src/question_baseselect.ts
+++ b/src/question_baseselect.ts
@@ -106,6 +106,7 @@ export class QuestionSelectBase extends Question {
     }
     get choicesOrder(): string { return this.choicesOrderValue; }
     set choicesOrder(newValue: string) {
+        newValue = newValue.toLowerCase();
         if (newValue == this.choicesOrderValue) return;
         this.choicesOrderValue = newValue;
         this.onVisibleChoicesChanged();

--- a/src/question_matrixdropdownbase.ts
+++ b/src/question_matrixdropdownbase.ts
@@ -35,9 +35,9 @@ export class MatrixDropdownColumn extends Base implements ILocalizableOwner {
     public isRequired: boolean = false;
     public hasOther: boolean = false;
     public minWidth: string = "";
-    public cellType: string = "default";
-    public inputType: string = "text";
-    public choicesOrder: string = "none";
+    private cellTypeValue: string = "default";
+    private inputTypeValue: string = "text";
+    private choicesOrderValue: string = "none";
     public choicesByUrl: ChoicesRestfull;
     public colOwner: IMatrixColumnOwner = null;
     public validators: Array<SurveyValidator> = new Array<SurveyValidator>();
@@ -55,6 +55,18 @@ export class MatrixDropdownColumn extends Base implements ILocalizableOwner {
     }
     public getType() { return "matrixdropdowncolumn" }
 
+    public get choicesOrder(): string { return this.choicesOrderValue; }
+    public set choicesOrder(newValue: string) {
+      this.choicesOrderValue = newValue.toLowerCase();
+    }
+    public get inputType(): string { return this.inputTypeValue; }
+    public set inputType(newValue: string) {
+      this.inputTypeValue = newValue.toLowerCase();
+    }
+    public get cellType(): string { return this.cellTypeValue; }
+    public set cellType(newValue: string) {
+        this.cellTypeValue = newValue.toLowerCase();
+    }
     public get title(): string { return this.locTitle.text ? this.locTitle.text : this.name; }
     public set title(value: string) { this.locTitle.text = value; }
     public get fullTitle(): string { return this.getFullTitle(this.locTitle.textOrHtml); }
@@ -240,6 +252,7 @@ export class QuestionMatrixDropdownModelBase extends Question implements IMatrix
     }
     public get cellType(): string { return this.cellTypeValue; }
     public set cellType(newValue: string) {
+        newValue = newValue.toLowerCase();
         if (this.cellType == newValue) return;
         this.cellTypeValue = newValue;
         this.fireCallback(this.updateCellsCallback);

--- a/src/question_multipletext.ts
+++ b/src/question_multipletext.ts
@@ -20,7 +20,7 @@ export class MultipleTextItemModel extends Base implements IValidatorOwner, ILoc
     private locTitleValue: LocalizableString;
     private locPlaceHolderValue: LocalizableString;
     public isRequired: boolean = false;
-    public inputType: string = "text";
+    private inputTypeValue: string = "text";
     validators: Array<SurveyValidator> = new Array<SurveyValidator>();
 
     constructor(public name: any = null, title: string = null) {
@@ -38,6 +38,10 @@ export class MultipleTextItemModel extends Base implements IValidatorOwner, ILoc
         this.data = data;
     }
 
+    public get inputType(): string { return this.inputTypeValue; }
+    public set inputType(newValue: string) {
+      this.inputTypeValue = newValue.toLowerCase();
+    }
     public get title() { return this.locTitle.text ? this.locTitle.text : this.name; }
     public set title(value: string) { this.locTitle.text = value; }
     public get locTitle() { return this.locTitleValue; }

--- a/src/question_text.ts
+++ b/src/question_text.ts
@@ -5,7 +5,7 @@ import {LocalizableString} from "./localizablestring";
 
 export class QuestionTextModel extends Question {
     public size: number = 25;
-    public inputType: string = "text";
+    private inputTypeValue: string = "text";
     private locPlaceHolderValue: LocalizableString;
     constructor(public name: string) {
         super(name);
@@ -13,6 +13,11 @@ export class QuestionTextModel extends Question {
     }
     public getType(): string {
         return "text";
+    }
+    get inputType(): string { return this.inputTypeValue; }
+    set inputType(type: string) {
+      var value = type.toLowerCase();
+      this.inputTypeValue = (value === "datetime_local") ? "datetime-local" : value;
     }
     isEmpty(): boolean {  return super.isEmpty() || this.value === ""; }
     supportGoNextPageAutomatic() { return true; }

--- a/src/survey.ts
+++ b/src/survey.ts
@@ -30,7 +30,7 @@ export class SurveyModel extends Base implements ISurvey, ISurveyTriggerOwner, I
     public showCompletedPage: boolean = true;
     public requiredText: string = "*";
     public questionStartIndex: string = "";
-    public showProgressBar: string = "off";
+    private showProgressBarValue: string = "off";
     public storeOthersAsComment: boolean = true;
     public goNextPageAutomatic: boolean = false;
     public pages: Array<PageModel> = new Array<PageModel>();
@@ -164,18 +164,26 @@ export class SurveyModel extends Base implements ISurvey, ISurveyTriggerOwner, I
     }
     public get showQuestionNumbers(): string { return this.showQuestionNumbersValue; };
     public set showQuestionNumbers(value: string) {
+        value = value.toLowerCase();
+        value = (value === "onpage") ? "onPage" : value;
         if (value === this.showQuestionNumbers) return;
         this.showQuestionNumbersValue = value;
         this.updateVisibleIndexes();
     };
+    public get showProgressBar(): string { return this.showProgressBarValue; }
+    public set showProgressBar(newValue: string) {
+      this.showProgressBarValue = newValue.toLowerCase();
+    }
     public get processedTitle() { return this.processText(this.locTitle.textOrHtml); }
     public get questionTitleLocation(): string { return this.questionTitleLocationValue; };
     public set questionTitleLocation(value: string) {
+        value = value.toLowerCase();
         if (value === this.questionTitleLocationValue) return;
         this.questionTitleLocationValue = value;
     };
     public get mode(): string { return this.modeValue; }
     public set mode(value: string) {
+        value = value.toLowerCase();
         if (value == this.mode) return;
         if (value != "edit" && value != "display") return;
         this.modeValue = value;

--- a/tests/entries/test.ts
+++ b/tests/entries/test.ts
@@ -11,6 +11,7 @@ export * from '../surveytests';
 export * from '../surveytriggertests';
 export * from '../surveyvalidatortests';
 export * from '../textPreprocessorTests';
+export * from '../lowercasetests';
 
 // localization
 import '../../src/localization/russian';

--- a/tests/lowercasetests.ts
+++ b/tests/lowercasetests.ts
@@ -1,0 +1,92 @@
+import {SurveyModel} from "../src/survey";
+import {PageModel} from "../src/page";
+import {QuestionTextModel} from "../src/question_text";
+import {QuestionMultipleTextModel, MultipleTextItemModel} from "../src/question_multipletext";
+import {QuestionMatrixDropdownModelBase, MatrixDropdownColumn} from "../src/question_matrixdropdownbase";
+import {QuestionSelectBase} from "../src/question_baseselect";
+
+export default QUnit.module("Survey");
+
+QUnit.test("inputType value is always lower-case", function (assert) {
+    var question = new QuestionTextModel("text");
+    question.inputType = "TEXT";
+    assert.strictEqual(question.inputType, "text");
+});
+
+QUnit.test("inputType value is always lower-case", function (assert) {
+    var question = new QuestionTextModel("text");
+    question.inputType = "DATETIME_LOCAL";
+    assert.strictEqual(question.inputType, "datetime-local");
+});
+
+QUnit.test("choicesOrder value is always lower-case", function (assert) {
+    var question = new QuestionSelectBase("base");
+    question.choicesOrder = "RANDOM";
+    assert.strictEqual(question.choicesOrder, "random");
+});
+
+QUnit.test("navigationButtonsVisibility value is always lower-case", function (assert) {
+    var question = new PageModel("base");
+    question.navigationButtonsVisibility = "HIDE";
+    assert.strictEqual(question.navigationButtonsVisibility, "hide");
+});
+
+QUnit.test("MatrixDropdownColumn inputType value is always lower-case", function (assert) {
+    var question = new MatrixDropdownColumn("text");
+    question.inputType = "TEXT";
+    assert.strictEqual(question.inputType, "text");
+});
+
+QUnit.test("MatrixDropdownColumn cellType value is always lower-case", function (assert) {
+    var question = new MatrixDropdownColumn("base");
+    question.cellType = "CHECKBOX";
+    assert.strictEqual(question.cellType, "checkbox");
+});
+
+QUnit.test("MatrixDropdownColumn choicesOrder value is always lower-case", function (assert) {
+    var question = new MatrixDropdownColumn("base");
+    question.choicesOrder = "RANDOM";
+    assert.strictEqual(question.choicesOrder, "random");
+});
+
+QUnit.test("QuestionMatrixDropdownModelBase cellType value is always lower-case", function (assert) {
+    var question = new QuestionMatrixDropdownModelBase("base");
+    question.cellType = "RADIOGROUP";
+    assert.strictEqual(question.cellType, "radiogroup");
+});
+
+QUnit.test("MultipleTextItemModel inputType value is always lower-case", function (assert) {
+    var question = new MultipleTextItemModel("text");
+    question.inputType = "COLOR";
+    assert.strictEqual(question.inputType, "color");
+});
+
+QUnit.test("SurveyModel showQuestionNumbers value is always lower-case", function (assert) {
+    var question = new SurveyModel("text");
+    question.showQuestionNumbers = "OFF";
+    assert.strictEqual(question.showQuestionNumbers, "off");
+});
+
+QUnit.test("SurveyModel showQuestionNumbers value handles onPage special case", function (assert) {
+    var question = new SurveyModel("text");
+    question.showQuestionNumbers = "ONPAGE";
+    assert.strictEqual(question.showQuestionNumbers, "onPage");
+});
+
+QUnit.test("SurveyModel questionTitleLocation value is always lower-case", function (assert) {
+    var question = new SurveyModel("text");
+    question.questionTitleLocation = "BOTTOM";
+    assert.strictEqual(question.questionTitleLocation, "bottom");
+});
+
+QUnit.test("SurveyModel showProgressBar value is always lower-case", function (assert) {
+    var question = new SurveyModel("text");
+    question.showProgressBar = "TOP";
+    assert.strictEqual(question.showProgressBar, "top");
+});
+
+QUnit.test("SurveyModel mode value is always lower-case", function (assert) {
+    var question = new SurveyModel("text");
+    question.mode = "DISPLAY";
+    assert.strictEqual(question.mode, "display");
+});


### PR DESCRIPTION
This is because GraphQL transmits enum values in uppercase. Note that we needed to add an exception for 'onPage' as it is not entirely lowercase, and an exception for 'datetime-local' as GraphQL enums don't accept dashes but accept underscores.