### PR TITLE
Pass question title to validate() methods

### DIFF
--- a/src/question.ts
+++ b/src/question.ts
@@ -305,7 +305,7 @@ export class Question extends QuestionBase implements IValidatorOwner {
         this.isValueChangedInSurvey = false;
     }
     //IValidatorOwner
-    getValidatorTitle(): string { return null; }
+    getValidatorTitle(): string { return this.name; }
 }
 JsonObject.metaData.addClass("question", [{ name: "title:text", serializationProperty: "locTitle" },
     { name: "commentText", serializationProperty: "locCommentText" },


### PR DESCRIPTION
This patch modifies `getValidatorTitle` of `QuestionBase` to return `this.name` instead of `null`, which seemed like an oversight.