### PR TITLE
Extract class active in rating

### DIFF
--- a/src/defaultCss/cssbootstrap.ts
+++ b/src/defaultCss/cssbootstrap.ts
@@ -24,7 +24,7 @@ export var defaultBootstrapCss = {
     paneldynamic: { root: "", button: "button" },
     multipletext: { root: "table", itemTitle: "", itemValue: "form-control" },
     radiogroup: { root: "form-inline", item: "radio", label: "", other: "" },
-    rating: { root: "btn-group", item: "btn btn-default" },
+    rating: { root: "btn-group", item: "btn btn-default", selected: "active" },
     text: "form-control",
     saveData: {root: "", saving: "alert alert-info", error: "alert alert-danger", success: "alert alert-success", saveAgainButton: ""},
     window: {

--- a/src/defaultCss/cssbootstrapmaterial.ts
+++ b/src/defaultCss/cssbootstrapmaterial.ts
@@ -23,7 +23,7 @@ export var defaultBootstrapMaterialCss = {
     paneldynamic: { root: "", button: "button" },
     multipletext: { root: "table", itemTitle: "", row: "form-group", itemValue: "form-control" },
     radiogroup: { root: "form-inline", item: "radio-inline", label: "radio-inline", other: "" },
-    rating: { root: "btn-group", item: "btn btn-default" },
+    rating: { root: "btn-group", item: "btn btn-default", selected: "active" },
     text: "form-control",
     saveData: {root: "", saving: "alert alert-info", error: "alert alert-danger", success: "alert alert-success", saveAgainButton: ""},
     window: {

--- a/src/defaultCss/cssstandard.ts
+++ b/src/defaultCss/cssstandard.ts
@@ -30,7 +30,7 @@ export var defaultStandardCss = {
     paneldynamic: { root: "", button: "" },
     multipletext: { root: "", itemTitle: "", row: "", itemValue: "" },
     radiogroup: { root: "sv_qcbc", item: "sv_q_radiogroup", label: "", other: "sv_q_other" },
-    rating: { root: "sv_q_rating", item: "sv_q_rating_item" },
+    rating: { root: "sv_q_rating", item: "sv_q_rating_item", selected: "active" },
     text: "",
     saveData: {root: "", saving: "", error: "", success: "", saveAgainButton: ""},
     window: {

--- a/src/knockout/koquestion_rating.ts
+++ b/src/knockout/koquestion_rating.ts
@@ -28,6 +28,7 @@ class QuestionRatingImplementor extends QuestionImplementor {
 
 export class QuestionRating extends QuestionRatingModel {
     public itemCss: string;
+    public selectedCss: string;
     constructor(public name: string) {
         super(name);
         new QuestionRatingImplementor(this);

--- a/src/knockout/koquestion_rating.ts
+++ b/src/knockout/koquestion_rating.ts
@@ -17,7 +17,8 @@ class QuestionRatingImplementor extends QuestionImplementor {
         (<QuestionRating>this.question).rateValuesChangedCallback = function () { self.onRateValuesChanged(); };
         this.question["koGetCss"] = function (val) {
             var css = (<QuestionRating>self.question).itemCss;
-            return self.question["koValue"]() == val.value ? css + " active" : css; };
+            var selected = (<QuestionRating>self.question).selectedCss;
+            return self.question["koValue"]() == val.value ? css + " " + selected : css; };
     }
     protected onRateValuesChanged() {
         this.koVisibleRateValues(this.getValues());
@@ -33,6 +34,7 @@ export class QuestionRating extends QuestionRatingModel {
     }
     protected onSetData() {
         this.itemCss = this.data["css"].rating.item;
+        this.selectedCss = this.data["css"].rating.selected;
     }
 }
 

--- a/src/react/reactquestionrating.tsx
+++ b/src/react/reactquestionrating.tsx
@@ -37,7 +37,7 @@ export class SurveyQuestionRating extends SurveyQuestionElementBase {
     protected renderItem(key: string, item: ItemValue, minText: JSX.Element, maxText: JSX.Element, cssClasses: any): JSX.Element {
         var isChecked = this.question.value == item.value;
         var className = cssClasses.item;
-        if (isChecked) className += " active";
+        if (isChecked) className += " " + cssClasses.selected;
         var itemText = this.renderLocString(item.locText);
         return <label key={key} className={className}>
             <input type="radio" style={{ display: "none" }} name={this.question.name} value={item.value} disabled={this.isDisplayMode} checked={this.question.value == item.value} onChange={this.handleOnChange} />

--- a/src/vue/rating.vue
+++ b/src/vue/rating.vue
@@ -24,7 +24,7 @@
         getCss(item) {
             let css = this.question.cssClasses.item;
             if (this.selection == item.value || this.question.value == item.value) {
-                css = css + " active";
+                css = css + " " + this.question.cssClasses.selected;
             }
             return css;
         }


### PR DESCRIPTION
This PR adds a possibility to customise the class applied on a selected rating button. This might be different in other css frameworks than bootstrap (eg. `is-active` in foundation and bulma)