### PR TITLE
Fix #620

### DIFF
--- a/src/vue/row.vue
+++ b/src/vue/row.vue
@@ -1,6 +1,6 @@
 <template>
     <div>
-        <div v-for="element in row.elements" :class="css.question.mainRoot" style="vertical-align:top" :id="element.id" :style="{display: element.visible ? 'inline-block': 'none', paddingLeft: getIndentSize(element, element.indent), paddingRight: getIndentSize(element, element.rightIndent), width: element.renderWidth }">
+        <div v-for="element in row.elements" :key="element.idValue" :class="css.question.mainRoot" style="vertical-align:top" :id="element.id" :style="{display: element.visible ? 'inline-block': 'none', paddingLeft: getIndentSize(element, element.indent), paddingRight: getIndentSize(element, element.rightIndent), width: element.renderWidth }">
             <h5 v-if="element.hasTitle" :class="css.question.title" v-show="survey.questionTitleLocation === 'top'"><survey-string :locString="element.locTitle"/></h5>
             <div v-if="element.hasDescription" :class="css.question.description" v-show="survey.questionTitleLocation === 'top'"><survey-string :locString="element.locDescription"/></div>
             <survey-errors v-if="survey.questionErrorLocation === 'top'" :question="element"/>


### PR DESCRIPTION
https://vuejs.org/v2/guide/list.html#key

> It is recommended to provide a `key` with `v-for` whenever possible, unless the iterated DOM content is simple, or you are intentionally relying on the default behavior for performance gains.

It might be a good idea to add `key`s to other `v-for`s as well.