### PR TITLE
Update React typings version in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "@types/knockout": "3.4.39",
     "@types/node": "7.0.4",
     "@types/qunit": "2.0.31",
-    "@types/react": "15.0.1",
+    "@types/react": "15.0.35",
     "@types/react-dom": "15.5.0",
     "ajv": "4.11.2",
     "babel-core": "6.22.1",


### PR DESCRIPTION
This update is required if working with Typescript version >= 2.4.0 - related to this it seems: https://gist.github.com/DanielRosenwasser/f5e7cbee0241b8edc1830233b160b46c#weak-types

The proposed React types version update here fixes this.  I came across this issue by trying to use string Enums in Typescript, which got released in 2.4.0. Should avoid headaches in the future.