### PR TITLE
Implement computed property for hasDescription in Page/Panel for vue: #818

### DIFF
--- a/src/vue/page.vue
+++ b/src/vue/page.vue
@@ -43,6 +43,9 @@
         get hasTitle () {
             return !!this.page.title && this.survey.showPageTitles;
         }
+        get hasDescription () {
+            return !!this.page.description;
+        }
         get num () {
             return this.page.num > 0 ? this.page.num + ". " : "";
         }

--- a/src/vue/panel.vue
+++ b/src/vue/panel.vue
@@ -47,6 +47,9 @@
         get hasTitle() {
             return this.question.title.length > 0
         }
+        get hasDescription () {
+            return !!this.question.description;
+        }
         get survey () {
             return this.question.survey;
         }


### PR DESCRIPTION
I believe this should fix issue #818, but I wasn't 100% sure if it's the correct business logic. I dug around and didn't see a `showDescription` property like there is with title, so I just implemented this getter to return true/false based on description alone.