### PR TITLE
Add has-error class to element component for Vue

### DIFF
--- a/src/defaultCss/cssbootstrap.ts
+++ b/src/defaultCss/cssbootstrap.ts
@@ -30,6 +30,7 @@ export var defaultBootstrapCss = {
     comment: "form-control",
     required: "",
     titleRequired: "",
+    hasError: "has-error",
     indent: 20
   },
   panel: {

--- a/src/defaultCss/cssbootstrapmaterial.ts
+++ b/src/defaultCss/cssbootstrapmaterial.ts
@@ -30,6 +30,7 @@ export var defaultBootstrapMaterialCss = {
     comment: "form-control",
     required: "",
     titleRequired: "",
+    hasError: "has-error",
     indent: 20
   },
   panel: {

--- a/src/defaultCss/cssstandard.ts
+++ b/src/defaultCss/cssstandard.ts
@@ -38,6 +38,7 @@ export var defaultStandardCss = {
     comment: "",
     required: "",
     titleRequired: "",
+    hasError: "",
     indent: 20,
     footer: "sv_q_footer"
   },

--- a/src/vue/element.vue
+++ b/src/vue/element.vue
@@ -1,5 +1,5 @@
 <template>
-    <div>
+    <div :class="getQuestionClass(element)">
         <div v-if="element.hasTitleOnLeftTop" :class="element.hasTitleOnLeft ? 'title-left' : ''">
             <h5 v-if="element.hasTitle" :class="element.cssClasses.title"><survey-string :locString="element.locTitle"/></h5>
             <div v-if="element.hasDescription" :class="element.cssClasses.description"><survey-string :locString="element.locDescription"/></div>
@@ -38,6 +38,12 @@ export class SurveyElement extends Vue {
       return "survey-customwidget";
     }
     return "survey-" + element.getTemplate();
+  }
+  getQuestionClass(element: QuestionModel) {
+    if (!!element.errors && element.errors.length > 0) {
+        return this.css.question.hasError
+    }
+    return '';
   }
   get hasErrorsOnTop() {
     return !this.element.isPanel && this.survey.questionErrorLocation === "top";


### PR DESCRIPTION
This commit adds the class defined in the `question.hasError` to the element in the html. This allows us to easily customize the look for the form fields and the titles when an error pops up. 

Note: this commit only adds it to the vue components. If the idea behind this is ok it should be added to the other frameworks also. 