### PR TITLE
Add decorator also for radio - extended fix for #1074

### DIFF
--- a/src/defaultCss/cssbootstrap.ts
+++ b/src/defaultCss/cssbootstrap.ts
@@ -92,6 +92,7 @@ export var defaultBootstrapCss = {
     label: "",
     itemControl: "",
     controlLabel: "",
+    materialDecorator: "circle",
     other: "sv_q_radiogroup_other"
   },
   rating: {

--- a/src/knockout/templates/question-radiogroup.html
+++ b/src/knockout/templates/question-radiogroup.html
@@ -5,7 +5,7 @@
             <label data-bind="css: question.koCss().label">
                 <input type="radio" data-bind="attr: {name: question.name + '_' + question.id, value: item.value, id: ($index() == 0) ? question.inputId : '', 'aria-label': question.locTitle.renderedHtml}, checked: question.koValue, enable: !question.koIsReadOnly(), css: question.koCss().itemControl"
                 />
-                <span class="circle"></span>
+                <span data-bind="css: question.koCss().materialDecorator"></span>
                 <span class="check"></span>
                 <span data-bind="css: question.koCss().controlLabel">
                     <!-- ko template: { name: 'survey-string', data: item.locText } -->

--- a/src/react/reactquestionradiogroup.tsx
+++ b/src/react/reactquestionradiogroup.tsx
@@ -102,7 +102,7 @@ export class SurveyQuestionRadiogroup extends SurveyQuestionElementBase {
             onChange={this.handleOnChange}
             aria-label={this.question.locTitle.renderedHtml}
           />
-          <span className="circle" />
+          <span className={cssClasses.materialDecorator} />
           <span className="check" />
           <span className={cssClasses.controlLabel}>{itemText}</span>
         </label>

--- a/src/vue/radiogroup.vue
+++ b/src/vue/radiogroup.vue
@@ -3,7 +3,7 @@
         <div v-for="(item, index) in question.visibleChoices" :key="item.value" :class="getItemClass(item)" >
             <label :class="question.cssClasses.label">
                 <input type="radio" :name="question.name + '_' + question.id" :value="item.value" :id="question.inputId + '_' + item.value" v-model="question.value" :disabled="question.isReadOnly" v-bind:aria-label="question.locTitle.renderedHtml" :class="question.cssClasses.itemControl"/>
-                <span class="circle"></span>
+                <span :class="question.cssClasses.materialDecorator"></span>
                 <span class="check"></span>
                 <span :class="question.cssClasses.controlLabel"><survey-string :locString="item.locText"/></span>
                 <survey-other-choice v-show="question.hasOther && question.isOtherSelected && index === choicesCount" :class="question.cssClasses.other" :question="question"/>


### PR DESCRIPTION
I added the Material decorator also to the circle class of the Radio buttons, because they were still static.